### PR TITLE
update ubuntu to 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   linters:
     name: Markdown linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Updates Ubuntu to 24, 20 is no longer supported and is deprecated.